### PR TITLE
Update 26-Normalizing_API_Responses_with_normalizr.md

### DIFF
--- a/26-Normalizing_API_Responses_with_normalizr.md
+++ b/26-Normalizing_API_Responses_with_normalizr.md
@@ -25,10 +25,10 @@ Our first exported Schema will be for the `todo` objects, and we'll specify `tod
 Our next schema called `arrayOfTodos` corresponds to the responses that contain arrays of `todo` objects.
 
 ```javascript
-import { Schema, arrayOf } from 'normalizr'
+import { schema } from 'normalizr'
 
-export const todo = new Schema('todos');
-export const arrayOfTodos = arrayOf(todo);
+export const todo = new schema.Entity('todos');
+export const arrayOfTodos = [ todo ];
 ```
 
 ### Updating our Action Creators


### PR DESCRIPTION
I propose to update this file, because  new version of `normalizr` not support `arrayOf` anymore