### PR TITLE
Add explanations to router-react v4.0.0 or superior

### DIFF
--- a/05-Adding_React_Router_to_the_Project.md
+++ b/05-Adding_React_Router_to_the_Project.md
@@ -49,6 +49,27 @@ const Root = ({ store }) => (
 
 _Note: the video contains a fix for weird address bar symbols stemming from an old release of `react-router`_
 
+_Note: the explanations in the video require a version of `react-router` previous to the 4.0.0. Starting in that version some changes have been included which require this slightly different syntax:_
+
+#### `Root.js` After (react-router v4.0.0 or superior)
+```javascript
+import React, { PropTypes } from 'react';
+import { Provider } from 'react-redux';
+import App from './App';
+import { BrowserRouter, Route } from 'react-router-dom'
+
+const Root = ({ store }) => (
+    <Provider store={store}>
+        <BrowserRouter>
+            <Route path="/" component={App} />
+        </BrowserRouter>
+    </Provider>
+);
+.
+.
+.
+
+
 [Recap at 1:09 in video](https://egghead.io/lessons/javascript-redux-adding-react-router-to-the-project?series=building-react-applications-with-idiomatic-redux#/tab-transcript)
 
 

--- a/06-Navigating_with_React_Router_Link.md
+++ b/06-Navigating_with_React_Router_Link.md
@@ -19,6 +19,22 @@ const Root = ({ store }) => (
 .
 ```
 
+_Note: the explanations in the video require a version of `react-router` previous to the 4.0.0. Starting in that version some changes have been included which require this slightly different syntax:_
+
+#### Update `Root.js` (react-router v4.0.0 or superior)
+```javascript
+const Root = ({ store }) => (
+  <Provider store={store}>
+    <Router history={browserHistory}>
+      <Route path="/:filter?" component={App} />
+    </Router>
+  </Provider>
+);
+.
+.
+.
+```
+
 ### Update Links in `Footer.js`
 We also need to update our visibility filter links inside of the footer.
 
@@ -128,6 +144,35 @@ FilterLink.propTypes = {
 
 export default FilterLink;
 ```
+
+_Note: the explanations in the video require a version of `react-router` previous to the 4.0.0. Starting in that version some changes have been included which require this slightly different syntax:_
+
+#### `FilterLink.js` After (react-router v4.0.0 or superior)
+```javascript
+import React, { PropTypes } from 'react';
+import { NavLink } from 'react-router';
+
+const FilterLink = ({ filter, children }) => (
+    <NavLink
+        exact
+        to={'/' + (filter === 'all' ? '' : filter)}
+        activeStyle={{
+            textDecoration: 'none',
+            color: 'black',
+        }}
+    >
+        {children}
+    </NavLink>
+);
+
+FilterLink.propTypes = {
+  filter: PropTypes.oneOf(['all', 'completed', 'active']).isRequired,
+  children: PropTypes.node.isRequired,
+};
+
+export default FilterLink;
+```
+
 
 ### More Cleanup to Do...
 We are no longer using the `setVisibilityFilter` action creator, so it can be removed from `src/actions/index.js`, leaving us with just `addTodo` and `toggleTodo` action creators.


### PR DESCRIPTION
I added some explanations and modified examples needed when react-router v4.0.0 or superior is used.