### PR TITLE
Add v4 version of App.js for React Router

### DIFF
--- a/07-Filtering_Redux_State_with_React_Router_Params.md
+++ b/07-Filtering_Redux_State_with_React_Router_Params.md
@@ -79,6 +79,20 @@ const App = ({ params }) => (
 );
 ```
 
+## `App.js` (react-router v4.0.0 or superior)
+```javascript
+const App = ({ match }) => (
+  <div>
+    <AddTodo />
+    <VisibleTodoList
+      filter={match.params.filter || 'all'}
+    />
+    <Footer />
+  </div>
+);
+```
+
+
 Now that our visibility filters are managed by React Router, we no longer need the `visibilityFilter` reducer. We can delete it, and also remove it from the `combineReducers()` declaration in `index.js`.
 
 


### PR DESCRIPTION
v4 uses `match.params` instead of `params`