### PR TITLE
Update 04-Refactoring_the_Entry_Point.md

### DIFF
--- a/04-Refactoring_the_Entry_Point.md
+++ b/04-Refactoring_the_Entry_Point.md
@@ -39,7 +39,7 @@ We will call our new file `configureStore.js`, and start by creating a funcion `
 
 We do this because this way our app doesn't have to know exactly how the store is created and whether or not we have subscribe handlers. It can just use the returned store in the `index.js` file.
 
-####`configureStore.js`
+#### `configureStore.js`
 ```javascript
 import { createStore } from 'redux'
 import throttle from 'lodash/throttle'


### PR DESCRIPTION
Correctly format `configureStore.js` by adding a space after `####`. Currently it looks like this:

![screen shot 2018-03-04 at 9 23 51 am](https://user-images.githubusercontent.com/5643640/36948306-dbc16c76-1fd0-11e8-8474-a7c3753119bd.png)
